### PR TITLE
timeout setter to populate the CURLOPT_TIMEOUT variable

### DIFF
--- a/pdfcrowd.php
+++ b/pdfcrowd.php
@@ -370,6 +370,12 @@ Possible reasons:
     function setUserAgent($user_agent) {
         $this->user_agent = $user_agent;
     }
+
+    function setTimeout($timeout) {
+        if (is_int($timeout) && $timeout > 0) {
+            $this->curlopt_timeout = $timeout;
+        }
+    }
     
     
 
@@ -379,7 +385,7 @@ Possible reasons:
     //                        Private stuff
     //
 
-    private $fields, $scheme, $port, $api_prefix;
+    private $fields, $scheme, $port, $api_prefix, $curlopt_timeout;
 
     public static $client_version = "2.7";
     public static $http_port = 80;
@@ -415,6 +421,9 @@ Links:
         curl_setopt($c, CURLOPT_POSTFIELDS, $postfields);
         curl_setopt($c, CURLOPT_DNS_USE_GLOBAL_CACHE, false);
         curl_setopt($c, CURLOPT_USERAGENT, $this->user_agent);
+        if (isset($this->curlopt_timeout)) {
+            curl_setopt($c, CURLOPT_TIMEOUT, $this->curlopt_timeout);
+        }
         if ($outstream) {
             $this->outstream = $outstream;
             curl_setopt($c, CURLOPT_WRITEFUNCTION, array($this, 'receive_to_stream'));


### PR DESCRIPTION
A problem I recently encountered with Pdfcrowd is that once the connection is setup, there is no way of determining a timeout or stoping a running request after having started the call to Pdfcrowd through the php client library. Killing the running job/ executing script is the only way to stop processing the request - which could be necessary due to Pdfcrowd only allowing one concurrently running pdf conversion at a time.

Cutting a long story short, since http_post is a private method on the Pdfcrowd instance and there is no chance of setting curl options on the request apart from changing the source and adding this possibility that's the reason for this pull request.